### PR TITLE
Added "iOS Design Cheat Sheet"

### DIFF
--- a/cheatsheets/iOS_Design_Cheat_Sheet.rb
+++ b/cheatsheets/iOS_Design_Cheat_Sheet.rb
@@ -258,7 +258,7 @@ cheatsheet do
   end
 
 
-# ~~~~~~~~~~~~ Table - Common Icons ~~~~~~~~~~~~
+# ~~~~~~~~~~~~ Table - Default Font Sizes ~~~~~~~~~~~~
   category do
     id 'Default Font Sizes'
  	header 'Default Font Size'


### PR DESCRIPTION
Hi Bogdan,

I added a new cheatsheet for iOS7 Design screen elements. This is based on ivomynttinen.com/blog/the-ios-7-design-cheat-sheet/ and I have communicated about reusing the data here with Ivo. An attribution has been added to the end and the docset has been tested in my Mac.

Regards
Deepu
