### PR TITLE
Add 'View counterpart in assistant editor'

### DIFF
--- a/cheatsheets/Xcode_Shortcuts.rb
+++ b/cheatsheets/Xcode_Shortcuts.rb
@@ -19,6 +19,10 @@ cheatsheet do
       name 'Select current file in project navigator'
     end
     entry do
+      command 'CMD+OPT+SHIFT+Z'
+      name 'View counterpart in assistant editor'
+    end
+    entry do
       command 'CMD+CTRL+Arrow Up'
       name 'Next counterpart'
     end


### PR DESCRIPTION
Because Xcode likes to switch to showing some random file in the assistant editor this shortcut is golden.
