### PR TITLE
Typo: assertIsNotNone takes a single argument

### DIFF
--- a/cheatsheets/Python_unittest_Assertions.rb
+++ b/cheatsheets/Python_unittest_Assertions.rb
@@ -106,7 +106,7 @@ cheatsheet do
       ```
       END
       td_notes '2.7'
-      name 'assertIsNotNone(a, b)'
+      name 'assertIsNotNone(x)'
       index_name 'assertIsNotNone'
     end
 


### PR DESCRIPTION
See here: https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertIsNotNone
