### PR TITLE
Fix for changes in Swift syntax

### DIFF
--- a/cheatsheets/Swift.rb
+++ b/cheatsheets/Swift.rb
@@ -11,8 +11,8 @@ cheatsheet do
       notes <<-'END'
         ``` swift
         class MyClass : OptionalSuperClass, OptionalProtocol1, OptionalProtocol2 {
-            var myProperty:String
-            var myOptionalProperty:String?
+            var myProperty: String
+            var myOptionalProperty: String?
             // More properties...
             init() {
                 myProperty = "Foo"
@@ -26,14 +26,16 @@ cheatsheet do
       name 'Methods'
       notes <<-'END'
         ``` swift
-        func doIt() -> Int {
-            return 0
-        }
-        func doIt(a:Int) -> Int {
-            return a
-        }
-        func doIt(a:Int, b:Int) -> Int {
-            return a+b
+        extension MyClass {
+            func doIt() -> Int {
+                return 0
+            }
+            func doIt(a: Int) -> Int {
+                return a
+            }
+            func doIt(a: Int, b: Int) -> Int {
+                return a + b
+            }
         }
         ```
       END
@@ -43,11 +45,11 @@ cheatsheet do
       name 'Objects'
       notes <<-'END'
         ``` swift
-        var a = MyClass()
+        let a = MyClass()
         a.myProperty
         a.doIt()
         a.doIt(1)
-        a.doIt(2, b:3)
+        a.doIt(2, b: 3)
         ```
       END
     end
@@ -60,7 +62,7 @@ cheatsheet do
             case Player = 1
             case Enemy = 2
         }
-        var type = CollisionType.Player
+        let type = CollisionType.Player
         ```
       END
     end
@@ -69,13 +71,13 @@ cheatsheet do
       name 'Variables'
       notes <<-'END'
         ``` swift
-        var mutableDouble:Double = 1.0
+        var mutableDouble: Double = 1.0
         mutableDouble = 2.0
-        let constantDouble:Double = 1.0
+        let constantDouble: Double = 1.0
         // constantDouble = 2.0 // will generate an error
 
         var mutableInferredDouble = 1.0
-        var optionalDouble:Double? = nil
+        var optionalDouble: Double? = nil
         optionalDouble = 1.0
 
         if let definiteDouble = optionalDouble {
@@ -107,7 +109,7 @@ cheatsheet do
         }
 
         // omits upper value, use ... to include
-        for i in 0..3 {
+        for i in 0..<3 {
         }
         ```
       END
@@ -117,19 +119,19 @@ cheatsheet do
       name 'Strings'
       notes <<-'END'
         ``` swift
-        var personOne = "Ray"
-        var personTwo = "Brian"
-        var combinedString = "\(personOne): Hello, \(personTwo)!"
+        let personOne = "Ray"
+        let personTwo = "Brian"
+        let combinedString = "\(personOne): Hello, \(personTwo)!"
         var tipString = "2499"
-        var tipInt = tipString.toInt()
+        let tipInt = tipString.toInt()
 
         extension Double {
             init (string: String) {
-                self = Double(string.bridgeToObjectiveC().doubleValue)
+                self = (string as NSString).doubleValue
             }
         }
         tipString = "24.99"
-        var tip = Double(string:tipString)
+        let tip = Double(string: tipString)
         ```
       END
     end
@@ -138,14 +140,14 @@ cheatsheet do
       name 'Arrays'
       notes <<-'END'
         ``` swift
-        var person1 = "Ray"
-        var person2 = "Brian"
-        var array:String[] = [person1, person2]
-        array += "Waldo"
+        let person1 = "Ray"
+        let person2 = "Brian"
+        var array: [String] = [person1, person2]
+        array += ["Waldo"]
         for person in array {
             println("person: \(person)")
         }
-        var waldo = array[2]
+        let waldo = array[2]
         ```
       END
     end
@@ -154,9 +156,10 @@ cheatsheet do
       name 'Dictionaries'
       notes <<-'END'
         ``` swift
-        var dict:Dictionary<String, String> = ["Frog": "Kermit", "Pig": "Ms. Piggy", "Weirdo": "Gonzo" ]
+        var dict: Dictionary<String, String> = ["Frog": "Kermit", "Pig": "Ms. Piggy", "Weirdo": "Gonzo"]
         dict["Weirdo"] = "Felipe"
-        dict["Frog"] = nil // delete frog for (type, muppet) in dict {
+        dict["Frog"] = nil // delete frog 
+        for (type, muppet) in dict {
             println("type: \(type), muppet: \(muppet)")
         }
         ```


### PR DESCRIPTION
This fixes the Swift cheat sheet for changes in Array, open-ended interval, and Dictionary. Also improves whitespace and uses `let` wherever appropriate.
