### PR TITLE
The HTTP cookie example line is misplaced

### DIFF
--- a/cheatsheets/HTTP_Header_Fields.rb
+++ b/cheatsheets/HTTP_Header_Fields.rb
@@ -477,10 +477,10 @@ cheatsheet do
     
     entry do
       td_notes <<-'END'
-      Set-Cookie: UserID=JohnDoe; Max-Age=3600; Version=
+      An HTTP cookie
 
       ```
-      An HTTP cookie
+      Set-Cookie: UserID=JohnDoe; Max-Age=3600; Version=
       ```
       Status: Permanent - Standard
       END


### PR DESCRIPTION
Introduction line and example line of HTTP cookie is misplaced.
