### PR TITLE
Added Computed Properties and Property Observers to Swift Cheatsheet. 

### DIFF
--- a/cheatsheets/Swift.rb
+++ b/cheatsheets/Swift.rb
@@ -14,6 +14,23 @@ cheatsheet do
             // Properties
             var myProperty: String
             var myOptionalProperty: String?
+            // Computed Properties
+            var myInt: Int = 1
+            var doubleInt {
+                get { return myInt * 2 }
+                set { myInt = newValue / 2 }
+            }
+            // Property Observers
+            var myOutput = 0 {
+              willSet{ 
+                println("setting myOutput to \(newValue)") 
+              }
+              didSet{ //never set greater than 10
+                if myOutput > 10 { 
+                  myOutput = 10 
+                }
+              }
+            }
             // Methods
             func myFunc() {
                 myOptionalProperty = "Foo"


### PR DESCRIPTION
Computed Properties and Property observers are two things that are always tripping me up in Swift. I always think "I want a custom setter and getter and reach for the `set` `get` when really I should be using `willSet` or `didSet`. 

I was so excited to see that the Dash Cheatsheets were up on github and that I could contribute. 

This is basically my first pull request, If I have done this incorrectly please let me know I willing to put in the work to be part of this community. 

Thanks for Dash! really enjoying it. 
