### PR TITLE
Add `Accept-Patch` response header

### DIFF
--- a/cheatsheets/HTTP_Header_Fields.rb
+++ b/cheatsheets/HTTP_Header_Fields.rb
@@ -503,6 +503,19 @@ cheatsheet do
     
     entry do
       td_notes <<-'END'
+      Specifies which patch document formats this server supports
+
+      ```
+      Accept-Patch: text/example;charset=utf-8
+      ```
+      Status: Permanent
+      END
+      name 'Accept-Patch'
+      index_name 'Accept-Patch (Response)'
+    end
+    
+    entry do
+      td_notes <<-'END'
       What partial content range types this server supports
 
       ```


### PR DESCRIPTION
This header was introduced by [RFC 5789, _PATCH Method for HTTP_, section 3.1](http://tools.ietf.org/html/rfc5789#section-3.1). It allows to specify the media types of patch documents that are accepted by the server in order to modify resources using the `PATCH` method.

The example code is taken directly from the RFC.
