### PR TITLE
Add PostgreSQL CLI cheat for logging in to a db with a given account.

### DIFF
--- a/cheatsheets/PostgreSQL_CLI.rb
+++ b/cheatsheets/PostgreSQL_CLI.rb
@@ -11,6 +11,11 @@ cheatsheet do
       command 'sudo -u postgres psql postgres'
       name 'Change to Postgres user and open psql prompt'
     end
+
+    entry do
+      command 'psql -d my_database -U my_username -W'
+      name 'Connect to my_database with role my_username and prompt for password. Requires md5 or password authentication.'
+    end
   end
 
   category do


### PR DESCRIPTION
- Assumes that md5 or password authentication is permitted on localhost.
    - See http://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html
    - See /var/lib/pgsql/data/pg_hba.conf