### PR TITLE
added separate listing for iPhone6+ virtual resolution 

### DIFF
--- a/cheatsheets/iOS_Design.rb
+++ b/cheatsheets/iOS_Design.rb
@@ -38,8 +38,16 @@ cheatsheet do
     entry do
       td_notes '1080 x 1920 px'
       td_notes '1920 x 1080 px'
-      name 'iPhone 6 Plus'
-      index_name 'iPhone 6 Plus Resolution'
+      name 'iPhone 6 Plus (Physical)'
+      index_name 'iPhone 6 Plus Physical Resolution'
+      notes ''
+    end
+
+	entry do
+      td_notes '1242 x 2208 px'
+      td_notes '2208 x 1242 px'
+      name 'iPhone 6 Plus (Virtual)'
+      index_name 'iPhone 6 Plus Virtual Resolution'
       notes ''
     end
 


### PR DESCRIPTION
The iPhone 6+ renders at a higher resolution and then gets down sampled to the physical screen size - see http://www.paintcodeapp.com/news/iphone-6-screens-demystified