### PR TITLE
Added "choose" to Capybara Cheat Sheets

### DIFF
--- a/cheatsheets/Capybara.rb
+++ b/cheatsheets/Capybara.rb
@@ -128,6 +128,14 @@ cheatsheet do
           Fills in fields for you. Pass the label text or the name of the input.'
       end
       entry do
+          name 'Choose'
+          notes '
+          ```ruby
+          choose \'Male\'
+          ```
+          Chooses a radio button. Pass the label text.'
+      end
+      entry do
           name 'Check'
           notes '
           ```ruby


### PR DESCRIPTION
Hi!

I added "choose" to Capybara Cheat Sheets.
This method can choose radio button on form, below for details.

* http://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Actions#choose-instance_method

Thank you so much.