### PR TITLE
Adding attributions to Git Flow cheatsheet

### DIFF
--- a/cheatsheets/Git_Flow.rb
+++ b/cheatsheets/Git_Flow.rb
@@ -115,4 +115,9 @@ cheatsheet do
       ```"
     end
   end
+
+    notes "
+        * Based on Git Flow cheatsheet by [Daniel Kummer](http://danielkummer.github.io/git-flow-cheatsheet/)
+        * Converted by [Robert Walker](https://github.com/robertwalker). Contributions welcome.
+    "
 end


### PR DESCRIPTION
Realized that I had not included attributions to this cheatsheet back when I created it.