### PR TITLE
Vim: Correction for switch case

### DIFF
--- a/cheatsheets/Vim.rb
+++ b/cheatsheets/Vim.rb
@@ -192,7 +192,7 @@ cheatsheet do
             notes 'If a [count] is given, do that many characters'
         end
         entry do
-            command '~{motion}'
+            command 'g~{motion}'
             name 'Switch case of {motion} text'
         end
         entry do


### PR DESCRIPTION
See http://vim.wikia.com/wiki/Switching_case_of_characters