### PR TITLE
Minor correction to 'Layout' shortcut for columns for SublimeText 3

### DIFF
--- a/cheatsheets/Sublime_Text_3.rb
+++ b/cheatsheets/Sublime_Text_3.rb
@@ -548,7 +548,7 @@ cheatsheet do
 
         entry do
             name 'Columns: 4'
-            command 'CMD+ALT+2'
+            command 'CMD+ALT+4'
         end
 
         entry do


### PR DESCRIPTION
The 4 column layout shortcut for SublimeText 3, 'CMD-ALT-2', should be 'CMD-ALT-4', since 'CMD-ALT-2' is also the 2 column layout.

Both 'CMD-ALT-2' and 'CMD-ALT-4'.

jonasbn