### PR TITLE
Add focus sidebar and focus group/pane shortcuts in Sublime Text 3

### DIFF
--- a/cheatsheets/Sublime_Text_3.rb
+++ b/cheatsheets/Sublime_Text_3.rb
@@ -78,6 +78,16 @@ cheatsheet do
         end
 
         entry do
+            name 'Focus sidebar'
+            command 'CTRL+0'
+        end
+
+        entry do
+            name 'Focus group/pane 1-9'
+            command 'CTRL+1-9'
+        end
+
+        entry do
             name 'Enter full screen'
             command 'CMD+CTRL+F'
         end


### PR DESCRIPTION
Questions about the keyboard shortcuts for focusing on the sidebar or one of the groups/panes are very common online, as this is a very basic use case that missing from many cheatsheets and guides. I'd love to see it added here, as I believe it will help many Dash+Sublime Text 3 users.