### PR TITLE
Update capybara cheatsheet with `attach_file`

### DIFF
--- a/cheatsheets/Capybara.rb
+++ b/cheatsheets/Capybara.rb
@@ -168,6 +168,14 @@ cheatsheet do
           Selects an option from a select tag.'
       end
       entry do
+          name 'Attach file'
+          notes '
+          ```ruby
+          attach_file \'Image\', \'path/to/image.jpg\'
+          ```
+          Attaches a file.'
+      end
+      entry do
           name 'Click button'
           notes '
           ```ruby


### PR DESCRIPTION
Adds missing method to attach files in a form with Capybara.