### PR TITLE
Update iOS design cheatsheet with the latest models of iPhone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.1.0
+  - 2.2.0
 git:
   submodules: false
 before_install:

--- a/cheatsheets/iOS_Design.rb
+++ b/cheatsheets/iOS_Design.rb
@@ -42,9 +42,9 @@ cheatsheet do
       td_notes '1920 x 1080 px'
       td_notes '414 x 736 points'
       td_notes '736 x 414 points'
-      name 'iPhone 6 Plus (Physical)'
-      index_name 'iPhone 6 Plus Physical Resolution'
-      notes ''
+      name 'iPhone 5.5-inch (Physical)'
+      index_name 'iPhone 5.5-inch Physical Resolution'
+      notes 'iPhone 6 Plus, iPhone 6S Plus, iPhone 7 Plus'
     end
 
     entry do
@@ -52,9 +52,9 @@ cheatsheet do
       td_notes '2208 x 1242 px'
       td_notes '414 x 736 points'
       td_notes '736 x 414 points'
-      name 'iPhone 6 Plus (Virtual)'
-      index_name 'iPhone 6 Plus Virtual Resolution'
-      notes ''
+      name 'iPhone 5.5-inch (Virtual)'
+      index_name 'iPhone 5.5-inch Virtual Resolution'
+      notes 'iPhone 6 Plus, iPhone 6S Plus, iPhone 7 Plus'
     end
 
     entry do
@@ -62,9 +62,9 @@ cheatsheet do
       td_notes '1334 x 750 px'
       td_notes '375 x 667 points'
       td_notes '667 x 375 points'
-      name 'iPhone 6'
-      index_name 'iPhone 6 Resolution'
-      notes ''
+      name 'iPhone 4.7-inch'
+      index_name 'iPhone 4.7-inch Resolution'
+      notes 'iPhone 6, iPhone 6S, iPhone 7'
     end
 
     entry do
@@ -72,9 +72,9 @@ cheatsheet do
       td_notes '1136 x 640 px'
       td_notes '320 x 568 points'
       td_notes '568 x 320 points'
-      name 'iPhone 5/5S/5C'
-      index_name 'iPhone 5/5S/5C Resolution'
-      notes ''
+      name 'iPhone 4-inch'
+      index_name 'iPhone 4-inch Resolution'
+      notes 'iPhone 5, iPhone 5S, iPhone 5C, iPhone SE'
     end
 
     entry do
@@ -82,9 +82,9 @@ cheatsheet do
       td_notes '960 x 640 px'
       td_notes '320 x 480 points'
       td_notes '480 x 320 points'
-      name 'iPhone 4/4S'
-      index_name 'iPhone 4/4S Resolution'
-      notes ''
+      name 'iPhone 3.5-inch'
+      index_name 'iPhone 3.5-inch Resolution'
+      notes 'iPhone 4, iPhone 4S'
     end
 
     entry do
@@ -164,9 +164,9 @@ cheatsheet do
       td_notes '`@3x`'
       td_notes '8bit RGB'
       td_notes  'Warm'
-      name 'iPhone 6 Plus'
-      index_name 'iPhone 6 Plus Display'
-      notes ''
+      name 'iPhone 5.5-inch'
+      index_name 'iPhone 5.5-inch Display'
+      notes 'iPhone 6 Plus, iPhone 6S Plus, iPhone 7 Plus'
     end
 
     entry do
@@ -175,9 +175,9 @@ cheatsheet do
       td_notes '`@2x`'
       td_notes '8bit RGB'
       td_notes  'Warm'
-      name 'iPhone 6'
-      index_name 'iPhone 6 Display'
-      notes ''
+      name 'iPhone 4.7-inch'
+      index_name 'iPhone 4.7-inch Display'
+      notes 'iPhone 6, iPhone 6S, iPhone 7'
     end
 
     entry do
@@ -186,8 +186,9 @@ cheatsheet do
       td_notes '`@2x`'
       td_notes '8bit RGB'
       td_notes  'Warm'
-      name 'iPhone 5/5S/5C'
-      index_name 'iPhone 5/5S/5C Display'
+      name 'iPhone 4-inch'
+      index_name 'iPhone 4-inch Display'
+      notes 'iPhone 5, iPhone 5S, iPhone 5C, iPhone SE'
     end
 
     entry do
@@ -196,9 +197,9 @@ cheatsheet do
       td_notes '`@2x`'
       td_notes '8bit RGB'
       td_notes  'Cool'
-      name 'iPhone 4/4S'
-      index_name 'iPhone 4/4S Display'
-      notes ''
+      name 'iPhone 3.5-inch'
+      index_name 'iPhone 3.5-inch Resolution'
+      notes 'iPhone 4, iPhone 4S'
     end
 
     entry do
@@ -231,6 +232,7 @@ cheatsheet do
       td_notes 'Warm'
       name 'iPad Pro 12.9-inch'
       index_name 'iPad Pro 12.9-inch Display'
+      notes ''
     end
 
     entry do
@@ -281,9 +283,9 @@ cheatsheet do
       td_notes '1024 x 1024 px'
       td_notes '120 x 120 px'
       td_notes '87 x 87 px'
-      name 'iPhone 6 Plus'
-      index_name 'iPhone 6 Plus Dimensions'
-      notes ''
+      name 'iPhone 5.5-inch'
+      index_name 'iPhone 5.5-inch Dimensions'
+      notes 'iPhone 6 Plus, iPhone 6S Plus, iPhone 7 Plus'
     end
 
     entry do
@@ -291,8 +293,9 @@ cheatsheet do
       td_notes '1024 x 1024 px'
       td_notes '80 x 80 px'
       td_notes '58 x 58 px'
-      name 'iPhone 6'
-      index_name 'iPhone 6 Dimensions'
+      name 'iPhone 4.7-inch'
+      index_name 'iPhone 4.7-inch Dimensions'
+      notes 'iPhone 6, iPhone 6S, iPhone 7'
     end
 
     entry do
@@ -300,9 +303,9 @@ cheatsheet do
       td_notes '1024 x 1024 px'
       td_notes '80 x 80 px'
       td_notes '58 x 58 px'
-      name 'iPhone 5/5S/5C'
-      index_name 'iPhone 5/5S/5C Dimensions'
-      notes ''
+      name 'iPhone 4-inch'
+      index_name 'iPhone 4-inch Dimensions'
+      notes 'iPhone 5, iPhone 5S, iPhone 5C, iPhone SE'
     end
 
     entry do
@@ -310,9 +313,9 @@ cheatsheet do
       td_notes '1024 x 1024 px'
       td_notes '80 x 80 px'
       td_notes '58 x 58 px'
-      name 'iPhone 4/4S'
-      index_name 'iPhone 4/4S Dimensions'
-      notes ''
+      name 'iPhone 3.5-inch'
+      index_name 'iPhone 3.5-inch Dimensions'
+      notes 'iPhone 4, iPhone 4S'
     end
 
     entry do
@@ -332,6 +335,7 @@ cheatsheet do
       td_notes '58 x 58 px'
       name 'iPad Pro 12.9-inch'
       index_name 'iPad Pro 12.9-inch Dimensions'
+      notes ''
     end
 
     entry do
@@ -350,7 +354,7 @@ cheatsheet do
      td_notes '40 x 40 px'
      td_notes '29 x 29 px'
      name 'iPad'
-      index_name 'iPad Dimensions'
+     index_name 'iPad Dimensions'
      notes '1st and 2nd Generation'
    end
 
@@ -370,9 +374,9 @@ cheatsheet do
       td_notes '132 px'
       td_notes '146 px'
       td_notes '1080 / 1920 px'
-      name 'iPhone 6 Plus'
-      index_name 'iPhone 6 Plus Design Elements'
-      notes ''
+      name 'iPhone 5.5-inch'
+      index_name 'iPhone 5.5-inch Design Elements'
+      notes 'iPhone 6 Plus, iPhone 6S Plus, iPhone 7 Plus'
     end
     
     entry do
@@ -380,9 +384,9 @@ cheatsheet do
       td_notes '88 / 64 px'
       td_notes '98 px'
       td_notes '750 / 1334 px'
-      name 'iPhone 6'
-      index_name 'iPhone 6 Design Elements'
-      notes ''
+      name 'iPhone 4.7-inch'
+      index_name 'iPhone 4.7-inch Design Elements'
+      notes 'iPhone 6, iPhone 6S, iPhone 7'
     end
     
     entry do
@@ -390,9 +394,9 @@ cheatsheet do
       td_notes '88 / 64 px'
       td_notes '98 px'
       td_notes '640 / 1136 px'
-      name 'iPhone 5/5S/5C'
-      index_name 'iPhone 5/5S/5C Design Elements'
-      notes ''
+      name 'iPhone 4-inch'
+      index_name 'iPhone 4-inch Design Elements'
+      notes 'iPhone 5, iPhone 5S, iPhone 5C, iPhone SE'
     end
 
     entry do
@@ -400,9 +404,9 @@ cheatsheet do
       td_notes '88 / 64 px'
       td_notes '98 px'
       td_notes '640 / 960 px'
-      name 'iPhone 4/4S'
-      index_name 'iPhone 4/4S Design Elements'
-      notes ''
+      name 'iPhone 3.5-inch'
+      index_name 'iPhone 3.5-inch Design Elements'
+      notes 'iPhone 4, iPhone 4S'
     end
 
 
@@ -447,30 +451,30 @@ cheatsheet do
     entry do
       td_notes '66 x 66 px'
       td_notes '75 x 75 px (max 144 x 96 px)'
-      name 'iPhone 6 Plus'
-      index_name 'iPhone 6 Plus Icons'
-      notes ''
+      name 'iPhone 5.5-inch'
+      index_name 'iPhone 5.5-inch Icons'
+      notes 'iPhone 6 Plus, iPhone 6S Plus, iPhone 7 Plus'
     end
     entry do
       td_notes '44 x 44 px'
       td_notes '50 x 50 px (max 96 x 64 px)'
-      name 'iPhone 6'
-      index_name 'iPhone 6 Icons'
-      notes ''
+      name 'iPhone 4.7-inch'
+      index_name 'iPhone 4.7-inch Icons'
+      notes 'iPhone 6, iPhone 6S, iPhone 7'
     end
     entry do
       td_notes '44 x 44 px'
       td_notes '50 x 50 px (max 96 x 64 px)'
-      name 'iPhone 5/5S/5C'
-      index_name 'iPhone 5/5S/5C Icons'
-      notes ''
+      name 'iPhone 4-inch'
+      index_name 'iPhone 4-inch Icons'
+      notes 'iPhone 5, iPhone 5S, iPhone 5C, iPhone SE'
     end
     entry do
       td_notes '44 x 44 px'
       td_notes '50 x 50 px (max 96 x 64 px)'
-      name 'iPhone 4/4S'
-      index_name 'iPhone 4/4S'
-      notes ''
+      name 'iPhone 3.5-inch'
+      index_name 'iPhone 3.5-inch Icons'
+      notes 'iPhone 4, iPhone 4S'
     end
     entry do
       td_notes '44 x 44 px'
@@ -496,7 +500,7 @@ cheatsheet do
   end
 
   category do
-    id 'Default Font Sizes iPhone 5/5C/5S/6'
+    id 'Default Font Sizes iPhone 5/5C/5S/SE/6/6S/7'
     header 'Label Type'
     header 'Default Font Size'
     header 'Default Font Weight'
@@ -505,40 +509,40 @@ cheatsheet do
       td_notes '34 px'
       td_notes 'Medium'
       name 'Navigation bar title'
-      index_name 'iPhone 5/5C/5S/6 Navigation Bar Title'
+      index_name 'iPhone 5/5C/5S/SE/6/6S/7 Navigation Bar Title'
     end
 
     entry do
       td_notes '34 px'
       td_notes 'Light'
       name 'Regular buttons'
-      index_name 'iPhone 5/5C/5S/6 Regular Buttons'
+      index_name 'iPhone 5/5C/5S/SE/6/6S/7 Regular Buttons'
     end
 
     entry do
       td_notes '34 px'
       td_notes 'Light'
       name 'Table header'
-      index_name 'iPhone 5/5C/5S/6 Table Header'
+      index_name 'iPhone 5/5C/5S/SE/6/6S/7 Table Header'
     end
 
     entry do
       td_notes '28 px'
       td_notes 'Regular'
       name 'Table label'
-      index_name 'iPhone 5/5C/5S/6 Table Label'
+      index_name 'iPhone 5/5C/5S/SE/6/6S/7 Table Label'
     end
 
     entry do
       td_notes '20 px'
       td_notes 'Regular'
       name 'Tab bar icon labels'
-      index_name 'iPhone 5/5C/5S/6 Tab Bar Icon Labels'
+      index_name 'iPhone 5/5C/5S/SE/6/6S/7 Tab Bar Icon Labels'
     end
   end
 
   category do
-    id 'Default Font Sizes iPhone 6 Plus'
+    id 'Default Font Sizes iPhone 6 Plus/6S Plus/7 Plus'
     header 'Label Type'
     header 'Default Font Size'
     header 'Default Font Weight'
@@ -547,35 +551,35 @@ cheatsheet do
       td_notes '48 px'
       td_notes 'Medium'
       name 'Navigation bar title'
-      index_name 'iPhone 6 Plus Navigation Bar Title'
+      index_name 'iPhone 6 Plus/6S Plus/7 Plus Navigation Bar Title'
     end
 
     entry do
       td_notes '48 px'
       td_notes 'Light'
       name 'Regular buttons'
-      index_name 'iPhone 6 Plus Regular Buttons'
+      index_name 'iPhone 6 Plus/6S Plus/7 Plus Regular Buttons'
     end
 
     entry do
       td_notes '48 px'
       td_notes 'Light'
       name 'Table header'
-      index_name 'iPhone 6 Plus Table Header'
+      index_name 'iPhone 6 Plus/6S Plus/7 Plus Table Header'
     end
 
     entry do
       td_notes '44 px'
       td_notes 'Regular'
       name 'Table label'
-      index_name 'iPhone 6 Plus Table Label'
+      index_name 'iPhone 6 Plus/6S Plus/7 Plus Table Label'
     end
 
     entry do
       td_notes '30 px'
       td_notes 'Regular'
       name 'Tab bar icon labels'
-      index_name 'iPhone 6 Plus Tab Bar Icon Labels'
+      index_name 'iPhone 6 Plus/6S Plus/7 Plus Tab Bar Icon Labels'
     end
   end
 
@@ -598,26 +602,26 @@ cheatsheet do
 
     entry do
       td_notes 'Height: Regular | Width: Compact'
-      name 'iPhone 6 Plus - Portrait'
-      index_name 'iPhone 6 Plus Portrait Size Class'
+      name 'iPhone 6 Plus/6S Plus/7 Plus - Portrait'
+      index_name 'iPhone 6 Plus/6S Plus/7 Plus Portrait Size Class'
     end
 
     entry do
       td_notes 'Height: Compact | Width: Regular'
-      name 'iPhone 6 Plus - Landscape'
-      index_name 'iPhone 6 Plus Landscape Size Class'
+      name 'iPhone 6 Plus/6S Plus/7 Plus - Landscape'
+      index_name 'iPhone 6 Plus/6S Plus/7 Plus Landscape Size Class'
     end
 
     entry do
       td_notes 'Height: Regular | Width: Compact'
-      name 'iPhone 6 and Before - Portrait'
-      index_name 'iPhone 6 and Before Portrait Size Class'
+      name 'iPhone 7 and Before - Portrait'
+      index_name 'iPhone 7 and Before Portrait Size Class'
     end
 
     entry do
       td_notes 'Height: Compact | Width: Compact'
-      name 'iPhone 6 and Before - Landscape'
-      index_name 'iPhone 6 and Before Landscape Size Class'
+      name 'iPhone 7 and Before - Landscape'
+      index_name 'iPhone 7 and Before Landscape Size Class'
     end
   end
 


### PR DESCRIPTION
I've added the latest model of iPhone in the cheatsheet (iPhone SE, iPhone 6S, iPhone 7, iPhone 6S Plus, iPhone 7 Plus). 
I've used the screen size to name the groups of models that share the same characteristics (for example, iPhone 4.7-inch to group the iPhones 6, 6S and 7). The corresponding models are listed in notes as for the models of iPad.