### PR TITLE
Missing dash in resize pane width

### DIFF
--- a/cheatsheets/tmux.rb
+++ b/cheatsheets/tmux.rb
@@ -412,7 +412,7 @@ cheatsheet do
     end
 
     entry do
-      command 'PREFIX-: resize pane -x ##'
+      command 'PREFIX-: resize-pane -x ##'
       name 'Resize the current pane to `##` lines wide'
     end
 


### PR DESCRIPTION
I am not sure, I have not tested this, but I was reading up on the pane resizing and this looks like a typo.