### PR TITLE
Added HTTP status code 418

### DIFF
--- a/cheatsheets/HTTP_Status_Codes.rb
+++ b/cheatsheets/HTTP_Status_Codes.rb
@@ -229,6 +229,13 @@ cheatsheet do
       name '417 Expectation failed'
       notes "The server cannot meet the requirements of the Expect request-header field."
     end
+    
+    entry do
+      name '418 I\'m a teapot'
+      notes "Any attempt to brew coffee with a teapot should result in the error code \"418 I'm a teapot\". The resulting entity body MAY be short and stout.
+
+      HTCPCP - [RFC 2324](https://tools.ietf.org/html/rfc2324#section-2.3.2)"
+    end
 
     entry do
       name '421 Misdirected request'


### PR DESCRIPTION
Wikipedia: This code was defined in 1998 as one of the traditional IETF April Fools' jokes, in RFC 2324, Hyper Text Coffee Pot Control Protocol, and is not expected to be implemented by actual HTTP servers. The RFC specifies this code should be returned by teapots requested to brew coffee. This HTTP status is used as an Easter egg in some websites, including Google.com. :)