### PR TITLE
Update git clone commands for git 2.13.0 changes

### DIFF
--- a/cheatsheets/Git.rb
+++ b/cheatsheets/Git.rb
@@ -19,7 +19,7 @@ cheatsheet do
       name 'Clone an existing repository and all its sub-modules recursively'
       notes "
         ```
-        git clone --recursive ssh://user@domain.tld/repo.git
+        git clone --recurse-submodules ssh://user@domain.tld/repo.git
         ```"
     end
 
@@ -570,7 +570,7 @@ cheatsheet do
       
       or 
       
-      Run `git clone --recursive ssh://user@domain.tld/repo.git`
+      Run `git clone --recurse-submodules ssh://user@domain.tld/repo.git`
       "
     end
 


### PR DESCRIPTION
git 2.13.0 removed the --recursive command and made the change to --recurse-submodules mandatory. See https://git-scm.com/docs/git-clone/2.13.0 that removes the old --recursive argument.