### PR TITLE
Remove invalid delete commands from tmux cheatsheet

### DIFF
--- a/cheatsheets/tmux.rb
+++ b/cheatsheets/tmux.rb
@@ -273,16 +273,6 @@ cheatsheet do
     end
 
     entry do
-      name 'Delete entire line'
-      command 'd'
-    end
-
-    entry do
-      name 'Delete to end of line'
-       command 'D'
-    end
-
-    entry do
       name 'End of line'
       command '$'
     end


### PR DESCRIPTION
In tmux's copy mode, there's no way to delete content. I suspect these
commands may have been originally copied from a general Vim cheatsheet.

cc @jongold who first added this.