### PR TITLE
Remove non-standard split mappings

### DIFF
--- a/cheatsheets/tmux.rb
+++ b/cheatsheets/tmux.rb
@@ -122,27 +122,13 @@ cheatsheet do
 
     entry do
       command 'PREFIX-%'
-      name 'Vertical split (Standard)'
-    end
-
-    entry do
-      command 'PREFIX-|'
-      name 'Vertical split (Personal)'
-      notes 'In tmux.conf: `bind-key | split-window -v`'
+      name 'Vertical split'
     end
 
     entry do
       command 'PREFIX-"'
-      name 'Horizontal split (Standard)'
+      name 'Horizontal split'
     end
-
-    entry do
-      command 'PREFIX- -'
-      name 'Horizontal split (Personal)'
-      notes 'In tmux.conf: `bind-key - split-window -h`'
-    end
-
-
 
     entry do
       command 'PREFIX-o'


### PR DESCRIPTION
I don't think it makes sense to include these mappings in a cheat
cheat. They are a personal preference.

The standard split mappings are already listed.