### PR TITLE
vim: Correct split commands

### DIFF
--- a/cheatsheets/Vim.rb
+++ b/cheatsheets/Vim.rb
@@ -808,12 +808,12 @@ cheatsheet do
         end
 
         entry do
-            command 'CTRL-WV'
+            command 'CTRL-W v'
             name 'Vertical split current window'
         end
 
         entry do
-            command 'CTRL-WS'
+            command 'CTRL-W s'
             name 'Horizontal split current window'
         end
 


### PR DESCRIPTION
`CTRL-WV` is misleading. It should be `CTRL-W CTRL-V` or `CTRL-W v` (see docs below from `:help vsplit`). Since the latter uses less keys, I think it makes more sense to include.

```
CTRL-W CTRL-V						*CTRL-W_CTRL-V*
CTRL-W v						*CTRL-W_v*
:[N]vs[plit] [++opt] [+cmd] [file]			*:vs* *:vsplit*
		Like |:split|, but split vertically.  The windows will be
		spread out horizontally if
		1. a width was not specified,
		2. 'equalalways' is set,
		3. 'eadirection' isn't "ver", and
		4. one of the other windows is wider than the current or new
		   window.
		Note: In other places CTRL-Q does the same as CTRL-V, but here
		it doesn't!
```