### PR TITLE
Remove ASCII lookup entry

### DIFF
--- a/cheatsheets/Vim.rb
+++ b/cheatsheets/Vim.rb
@@ -236,10 +236,6 @@ cheatsheet do
           command '*'
           name 'Highlight all occurrences of word under cursor'
         end
-        entry do
-          command 'ga'
-          name 'Show ASCII value of char under cursor'
-        end
     end
 
     category do


### PR DESCRIPTION
The Vim cheatsheet is very long. I think it would be helpful to limit it to more commonly used features.

Looking up the ASCII value of a character *seems* like something that would be infrequently needed. It's difficult to balance what say what should or shouldn't be included, but to support my proposal I checked a couple of popular books, Practical Vim and Pro Vim, and couldn't find any mention of this command in either.

Any thoughts?

(cc @Robert-M-Muench who originally added this in #271).