### PR TITLE
Vim: Update substitute entries

### DIFF
--- a/cheatsheets/Vim.rb
+++ b/cheatsheets/Vim.rb
@@ -278,7 +278,6 @@ cheatsheet do
             * `[c]` Confirm each substitution. Vim positions the cursor on the matching string. You can type:
               * `y`      to substitute this match
               * `n`      to skip this match
-              * `<Esc>`   to skip this match
               * `a`      to substitute this and all remaining matches
               * `q`      to quit substituting
               * `CTRL-E`  to scroll the screen up


### PR DESCRIPTION
From `:help s_flags` in vim 8.1.1:

```
[c]	Confirm each substitution.  Vim highlights the matching string (with
	|hl-IncSearch|).  You can type:				*:s_c*
	    'y'	    to substitute this match
	    'l'	    to substitute this match and then quit ("last")
	    'n'	    to skip this match
	    <Esc>   to quit substituting
	    'a'	    to substitute this and all remaining matches {not in Vi}
	    'q'	    to quit substituting {not in Vi}
	    CTRL-E  to scroll the screen up {not in Vi, not available when
			compiled without the |+insert_expand| feature}
	    CTRL-Y  to scroll the screen down {not in Vi, not available when
			compiled without the |+insert_expand| feature}
```