### PR TITLE
Update atom cheatsheet for settings

### DIFF
--- a/cheatsheets/Atom.rb
+++ b/cheatsheets/Atom.rb
@@ -22,6 +22,10 @@ cheatsheet do
       command 'CTRL+SHIFT+L'
       name 'Select grammar (set/change syntax)'
     end
+    entry do
+      command 'CMD+,'
+      name 'Open Settings view'
+    end
   end
 
   category do


### PR DESCRIPTION
Small addition to Atom cheatsheet to add keyboard shortcut to pull up Settings view.