### PR TITLE
Update Android_Codenames_Tags_Build_Numbers.rb

### DIFF
--- a/cheatsheets/Android_Codenames_Tags_Build_Numbers.rb
+++ b/cheatsheets/Android_Codenames_Tags_Build_Numbers.rb
@@ -12,7 +12,6 @@ cheatsheet do
     entry do
       command '29'
       name '10'
-      notes ''
     end
     entry do
       command '28'

--- a/cheatsheets/Android_Codenames_Tags_Build_Numbers.rb
+++ b/cheatsheets/Android_Codenames_Tags_Build_Numbers.rb
@@ -10,6 +10,11 @@ cheatsheet do
     id 'API Levels'
 
     entry do
+      command '29'
+      name '10'
+      notes ''
+    end
+    entry do
       command '28'
       name '9'
       notes 'Pie'


### PR DESCRIPTION
Added Android 10, API 29.  Removed notes element, no codenames from now on.