### PR TITLE
Updates to the Dist::Zilla / dzil cheatsheet

### DIFF
--- a/cheatsheets/dzil.rb
+++ b/cheatsheets/dzil.rb
@@ -405,6 +405,11 @@ cheatsheet do
             command 'AUTHOR_TESTING'
             name 'See also: `smoke --author`'
         end
+        entry do
+            command 'HARNESS_OPTIONS'
+            name 'Similar to the: `--jobs` option supported by several commands. Allows for specification of number of test jobs to run in parallel, e.g. `HARNESS_OPTIONS=j9`'
+        end
+
     end
 
     notes <<-'END'

--- a/cheatsheets/dzil.rb
+++ b/cheatsheets/dzil.rb
@@ -408,7 +408,7 @@ cheatsheet do
     end
 
     notes <<-'END'
-    This cheatsheet is based on Dist::Zilla 6.009.
+    This cheatsheet is based on Dist::Zilla 6.014.
 
     Visit http://dzil.org for more information.
 


### PR DESCRIPTION
Updates to the Dist::Zilla cheatsheet / `dzil`.

- Added entry for the `cover` command (via extension, which is also mentioned)
- Added mention of extension for `xtest` command (as for the `cover` command above)
- Bumped version for Dist::Zilla, since the previous addition of the `--jobs` flag to release, was introduced in 6.014 and the cheatsheet was based on 6.009, so every thing should be in balance again