### PR TITLE
Fix HTTP Codes for Rails to distinguish 401/403

### DIFF
--- a/cheatsheets/HTTP_Status_Codes_Rails.rb
+++ b/cheatsheets/HTTP_Status_Codes_Rails.rb
@@ -174,7 +174,7 @@ INTRO
     entry do
       command ':unauthorized'
       name '401 Unauthorized'
-      notes 'The requestor is not authorized to access the resource. This is similar to `402` but is used in cases where authentication is expected but has failed or has not been provided.'
+      notes 'The requestor is not authorized to access the resource. This is similar to `403` but is used in cases where authentication is expected but has failed or has not been provided.'
     end
 
     entry do
@@ -186,7 +186,7 @@ INTRO
     entry do
       command ':forbidden'
       name '403 Forbidden'
-      notes "The request was formatted correctly but the server is refusing to supply the requested resource. Unlike `402`, authenticating will not make a difference in the server's response."
+      notes "The request was formatted correctly but the server is refusing to supply the requested resource. Unlike `401`, authenticating will not make a difference in the server's response."
     end
 
     entry do


### PR DESCRIPTION
There was a typo in the 401 and 403 https status codes.