### PR TITLE
is_map_key is superhandy when I have two keys

### DIFF
--- a/cheatsheets/Elixir_Guards.rb
+++ b/cheatsheets/Elixir_Guards.rb
@@ -146,6 +146,7 @@ cheatsheet do
       `hd(list)`,
       `length(list)`,
       `map_size(map)`,
+      `is_map_key(map, key)`,
       `node()`, `node(pid | ref | port)`,
       `rem(integer, integer)`,
       `round(number)`,


### PR DESCRIPTION
When I have two keys that need to be together in the map, but if both are missing it's fine. 

`when not is_map_key(filter, "searchKey") and is_map_key(filter, "searchValue")`